### PR TITLE
Allow parametric encoder via --encoder

### DIFF
--- a/bbb_dl/ffmpeg.py
+++ b/bbb_dl/ffmpeg.py
@@ -18,7 +18,7 @@ from youtube_dl.postprocessor.ffmpeg import FFmpegPostProcessor, FFmpegPostProce
 class MyFFmpegPostProcessor(FFmpegPostProcessor):
     def run_ffmpeg_multiple_files(self, input_paths, out_path, opts, opts_before=[]):
         self.check_version()
-        
+
         # sanitze filename
         out_path = pathvalidate.sanitize_filename(out_path)
 
@@ -67,9 +67,10 @@ class MyFFmpegPostProcessor(FFmpegPostProcessor):
 
 
 class FFMPEG:
-    def __init__(self, ydl: YoutubeDL):
+    def __init__(self, ydl: YoutubeDL, encoder: str):
         self.pp = MyFFmpegPostProcessor(ydl)
         self.pp.check_version()
+        self._encoder = encoder
 
     def rescale_image(self, image, out_file, width, height):
         self.pp.run_ffmpeg(image, out_file, ["-vf", "pad=%s:%s:ow/2-iw/2:oh/2-ih/2" % (width, height)])
@@ -122,7 +123,7 @@ class FFMPEG:
             out_file,
             [
                 "-c:v",
-                "libx264",
+                self._encoder,
                 "-t",
                 str(duration),
                 "-pix_fmt",
@@ -159,7 +160,7 @@ class FFMPEG:
                 "-vf",
                 "scale=%s:%s" % (width, height),
                 "-c:v",
-                "libx264",
+                self._encoder,
                 "-pix_fmt",
                 "yuv420p",
             ],

--- a/bbb_dl/ffmpeg.py
+++ b/bbb_dl/ffmpeg.py
@@ -123,7 +123,7 @@ class FFMPEG:
             out_file,
             [
                 "-c:v",
-                self._encoder,
+                "libx264",
                 "-t",
                 str(duration),
                 "-pix_fmt",

--- a/bbb_dl/ffmpeg.py
+++ b/bbb_dl/ffmpeg.py
@@ -19,8 +19,8 @@ class MyFFmpegPostProcessor(FFmpegPostProcessor):
     def run_ffmpeg_multiple_files(self, input_paths, out_path, opts, opts_before=[]):
         self.check_version()
 
-        # sanitze filename
-        out_path = pathvalidate.sanitize_filename(out_path)
+        # sanitize file path
+        out_path = pathvalidate.sanitize_filepath(out_path)
 
         oldest_mtime = min(os.stat(encodeFilename(path)).st_mtime for path in input_paths)
 

--- a/bbb_dl/main.py
+++ b/bbb_dl/main.py
@@ -76,7 +76,7 @@ class BBBDL(InfoExtractor):
         r'(?P<website>https?://[^/]+)/playback/presentation/2.0/playback.html\?.*?meetingId=(?P<id>[0-9a-f\-]+)'
     )
 
-    def __init__(self, verbose: bool, no_check_certificate: bool):
+    def __init__(self, verbose: bool, no_check_certificate: bool, encoder: str):
         if '_VALID_URL_RE' not in self.__dict__:
             BBBDL._VALID_URL_RE = re.compile(self._VALID_URL)
 
@@ -90,7 +90,7 @@ class BBBDL(InfoExtractor):
         self.verbose = verbose
         self.ydl = youtube_dl.YoutubeDL(ydl_options)
         self.set_downloader(self.ydl)
-        self.ffmpeg = FFMPEG(self.ydl)
+        self.ffmpeg = FFMPEG(self.ydl, encoder)
 
     def run(self, dl_url: str, add_webcam: bool, add_annotations: bool, add_cursor, keep_tmp_files: bool):
         m_obj = self._VALID_URL_RE.match(dl_url)
@@ -674,6 +674,14 @@ def get_parser():
         '--version', action='version', version='bbb-dl ' + __version__, help='Print program version and exit'
     )
 
+    parser.add_argument(
+        '--encoder',
+        dest='encoder',
+        type=str,
+        default='libx264',
+        help='Optional encoder to pass to ffmpeg (default libx264)',
+    )
+
     return parser
 
 
@@ -682,7 +690,7 @@ def main(args=None):
     parser = get_parser()
     args = parser.parse_args(args)
 
-    BBBDL(args.verbose, args.no_check_certificate).run(
+    BBBDL(args.verbose, args.no_check_certificate, args.encoder).run(
         args.URL,
         args.add_webcam,
         args.add_annotations,


### PR DESCRIPTION
This is useful for `h264_nvenc` encoders and such.

Couldn't test it since I have problems with libcairo on Windows, please test before merging.